### PR TITLE
Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,11 +280,6 @@ jobs:
       - restore_cache:
           key: nerves/deploy/{{ checksum ".target" }}-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - run:
-          name: rpi2
-          command: echo "rpi2" > .target
-      - restore_cache:
-          key: nerves/deploy/{{ checksum ".target" }}-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
-      - run:
           name: rpi
           command: echo "rpi" > .target
       - restore_cache:
@@ -313,7 +308,6 @@ jobs:
       - run:
           name: Deploy artifacts to Github
           command: ./ghr -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat deploy/RELEASE_NOTES)" -replace $CIRCLE_TAG deploy/artifacts
-
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,395 @@
+version: 2.0
+
+defaults: &defaults
+  docker:
+    - image: nervesproject/nerves_system_br:1.7.1
+  working_directory: "/tmp/nerves"
+
+elixir_version: &elixir_version
+  ELIXIR_VERSION: 1.8.2-otp-21
+  SECRET_KEY_BASE: ${SECRET_KEY_BASE:-BGC824f8kh1IQPXK7bUmXDigrw404rA7rivR96vGv4bhMIRogiaFN7Z6R4duZClA}
+  LIVE_VIEW_SIGNING_SALT: ${LIVE_VIEW_SIGNING_SALT:-2GiUN2NDLEnYT8I/3Q+XL6LGUGEKGogh}
+
+install_elixir: &install_elixir
+  run:
+    name: Install Elixir
+    command: |
+      wget https://repo.hex.pm/builds/elixir/v$ELIXIR_VERSION.zip
+      mkdir -p $HOME/bin
+      unzip -d $HOME/bin/elixir v$ELIXIR_VERSION.zip
+      echo 'export PATH=$HOME/bin/elixir/bin:$PATH' >> $BASH_ENV
+
+install_hex_rebar: &install_hex_rebar
+  run:
+    name: Install hex and rebar
+    command: |
+      mix local.hex --force
+      mix local.rebar --force
+
+install_nerves_bootstrap: &install_nerves_bootstrap
+  run:
+    name: Install nerves_bootstrap
+    command: |
+      mix archive.install hex nerves_bootstrap --force
+
+install_ghr: &install_ghr
+  run:
+    name: Install ghr (Github Releases)
+    command: |
+      wget https://github.com/tcnksm/ghr/releases/download/v0.9.0/ghr_v0.9.0_linux_amd64.tar.gz
+      tar xf ghr_v0.9.0_linux_amd64.tar.gz
+      ln -sf ghr_v0.9.0_linux_amd64/ghr .
+
+install_system_deps: &install_system_deps
+  run:
+    name: Install system dependencies
+    command: |
+      apt update
+      apt install -y zip
+
+fake_ssh_keys: &fake_ssh_keys
+  run:
+    name: Generage bogus keys
+    command: |
+      rm -f ~/.ssh/id_rsa
+      ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+
+build_assets: &build_assets
+  working_directory: "/tmp/nerves"
+  docker:
+    - image: circleci/node:8.11.3
+  steps:
+    - checkout
+    - restore_cache:
+        key: nerves/deps_fw/{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+    - restore_cache:
+        key: nerves/deps_phx/{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+    - run:
+        name: Build assets
+        command: |
+          cd nerves_key_quickstart_phx/assets
+          npm install
+          npm run deploy
+    - save_cache:
+        key: nerves/assets/{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+        paths:
+          - nerves_key_quickstart_phx/priv/static
+
+fetch_deps: &fetch_deps
+  steps:
+    - checkout
+    - <<: *fake_ssh_keys
+    - <<: *install_elixir
+    - <<: *install_hex_rebar
+    - <<: *install_nerves_bootstrap
+    - run:
+        name: Fetch fw deps
+        command: |
+          cd nerves_key_quickstart_fw
+          n=0
+          until [ $n -ge 5 ]; do
+            mix deps.get && break
+            n=$((n+1))
+            echo "Error while fetching deps. Retrying in 5 seconds"
+            sleep 5
+          done
+    - run:
+        name: Fetch phx deps
+        command: |
+          cd nerves_key_quickstart_phx
+          n=0
+          until [ $n -ge 5 ]; do
+            mix deps.get && break
+            n=$((n+1))
+            echo "Error while fetching deps. Retrying in 5 seconds"
+            sleep 5
+          done
+    - save_cache:
+        key: nerves/deps_fw/{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+        paths:
+          - nerves_key_quickstart_fw/deps
+    - save_cache:
+        key: nerves/deps_phx/{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+        paths:
+          - nerves_key_quickstart_phx/deps
+
+build_test: &build_test
+  steps:
+    - checkout
+    - <<: *fake_ssh_keys
+    - <<: *install_system_deps
+    - <<: *install_elixir
+    - <<: *install_hex_rebar
+    - <<: *install_nerves_bootstrap
+    - restore_cache:
+        key: nerves/deps_fw/{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+    - restore_cache:
+        key: nerves/deps_phx/{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+    - run:
+        name: Check formatting
+        command: |
+          cd nerves_key_quickstart_fw
+          mix format --check-formatted
+          cd ../nerves_key_quickstart_phx
+          mix format --check-formatted
+
+build: &build
+  steps:
+    - checkout
+    - <<: *fake_ssh_keys
+    - <<: *install_system_deps
+    - <<: *install_elixir
+    - <<: *install_hex_rebar
+    - <<: *install_nerves_bootstrap
+    - run: echo "$MIX_TARGET" > .target
+    - restore_cache:
+        key: nerves/deps_fw/{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+    - restore_cache:
+        key: nerves/deps_phx/{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+    - restore_cache:
+          key: nerves/assets/{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+    - run:
+        name: Fetch fw deps
+        command: |
+          cd nerves_key_quickstart_fw
+          n=0
+          until [ $n -ge 5 ]; do
+            mix deps.get && break
+            n=$((n+1))
+            echo "Error while fetching deps. Retrying in 5 seconds"
+            sleep 5
+          done
+    - run:
+        name: Build
+        command: |
+          cd nerves_key_quickstart_fw
+          mix compile
+          mix phx.digest
+    - run:
+        name: Create firmware
+        command: |
+          cd nerves_key_quickstart_fw
+          mix firmware
+          mix firmware.image
+    - run:
+          name: Create artifacts dir
+          command: mkdir -p deploy/artifacts
+    - run:
+        name: Copy firmware file
+        command: |
+          cp nerves_key_quickstart_fw/_build/*/nerves/images/*.fw deploy/artifacts/nerves_key_quickstart_${MIX_TARGET}.fw
+          zip nerves_key_quickstart_${MIX_TARGET}.zip nerves_key_quickstart_fw/nerves_key_quickstart_fw.img
+          cp nerves_key_quickstart_${MIX_TARGET}.zip deploy/artifacts
+          cp ./CHANGELOG.md deploy/CHANGELOG.md
+    - store_artifacts:
+        path: deploy
+        destination: images
+    - save_cache:
+        key: nerves/deploy/{{ checksum ".target" }}-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+        paths:
+          - deploy
+
+jobs:
+  fetch_deps:
+    <<: *defaults
+    environment:
+      <<: *elixir_version
+    <<: *fetch_deps
+
+  test:
+    <<: *defaults
+    environment:
+      <<: *elixir_version
+    <<: *build_test
+
+  build_assets:
+    environment:
+      <<: *elixir_version
+    <<: *build_assets
+
+  build_rpi3a:
+    <<: *defaults
+    environment:
+      <<: *elixir_version
+      MIX_TARGET: rpi3a
+    <<: *build
+
+  build_rpi3:
+    <<: *defaults
+    environment:
+      <<: *elixir_version
+      MIX_TARGET: rpi3
+    <<: *build
+
+  build_rpi2:
+    <<: *defaults
+    environment:
+      <<: *elixir_version
+      MIX_TARGET: rpi2
+    <<: *build
+
+  build_rpi:
+    <<: *defaults
+    environment:
+      <<: *elixir_version
+      MIX_TARGET: rpi
+    <<: *build
+
+  build_rpi0:
+    <<: *defaults
+    environment:
+      <<: *elixir_version
+      MIX_TARGET: rpi0
+    <<: *build
+
+  build_bbb:
+    <<: *defaults
+    environment:
+      <<: *elixir_version
+      MIX_TARGET: bbb
+    <<: *build
+
+  build_x86_64:
+    <<: *defaults
+    environment:
+      <<: *elixir_version
+      MIX_TARGET: x86_64
+    <<: *build
+
+  deploy:
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_ghr
+      - run:
+          name: Create Artifacts Dir
+          command: mkdir -p deploy
+      - run:
+          name: rpi3a
+          command: echo "rpi3a" > .target
+      - restore_cache:
+          key: nerves/deploy/{{ checksum ".target" }}-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+      - run:
+          name: rpi3
+          command: echo "rpi3" > .target
+      - restore_cache:
+          key: nerves/deploy/{{ checksum ".target" }}-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+      - run:
+          name: rpi2
+          command: echo "rpi2" > .target
+      - restore_cache:
+          key: nerves/deploy/{{ checksum ".target" }}-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+      - run:
+          name: rpi2
+          command: echo "rpi2" > .target
+      - restore_cache:
+          key: nerves/deploy/{{ checksum ".target" }}-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+      - run:
+          name: rpi
+          command: echo "rpi" > .target
+      - restore_cache:
+          key: nerves/deploy/{{ checksum ".target" }}-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+      - run:
+          name: rpi0
+          command: echo "rpi0" > .target
+      - restore_cache:
+          key: nerves/deploy/{{ checksum ".target" }}-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+      - run:
+          name: bbb
+          command: echo "bbb" > .target
+      - restore_cache:
+          key: nerves/deploy/{{ checksum ".target" }}-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+      # - run:
+      #     name: x86_64
+      #     command: echo "x86_64" > .target
+      # - restore_cache:
+      #     key: nerves/deploy/{{ checksum ".target" }}-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+      - run:
+          name: Create release notes
+          command: grep -Pazo "(?s)(?<=## ${CIRCLE_TAG})[^#]+" deploy/CHANGELOG.md | sed '/./,$!d' > deploy/RELEASE_NOTES
+      - store_artifacts:
+          path: deploy
+          destination: images
+      - run:
+          name: Deploy artifacts to Github
+          command: ./ghr -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat deploy/RELEASE_NOTES)" -replace $CIRCLE_TAG deploy/artifacts
+
+
+workflows:
+  version: 2
+  pipeline:
+    jobs:
+      - fetch_deps:
+          context: org-global
+      - test:
+          context: org-global
+          requires:
+            - fetch_deps
+      - build_assets:
+          context: org-global
+          requires:
+            - test
+      - build_rpi3a:
+          context: org-global
+          requires:
+            - build_assets
+          filters:
+            tags:
+              only: /.*/
+      - build_rpi3:
+          context: org-global
+          requires:
+            - build_assets
+          filters:
+            tags:
+              only: /.*/
+      - build_rpi2:
+          context: org-global
+          requires:
+            - build_assets
+          filters:
+            tags:
+              only: /.*/
+      - build_rpi:
+          context: org-global
+          requires:
+            - build_assets
+          filters:
+            tags:
+              only: /.*/
+      - build_rpi0:
+          context: org-global
+          requires:
+            - build_assets
+          filters:
+            tags:
+              only: /.*/
+      - build_bbb:
+          context: org-global
+          requires:
+            - build_assets
+          filters:
+            tags:
+              only: /.*/
+      # - build_x86_64:
+      #     context: org-global
+      #     requires:
+      #       - build_assets
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      - deploy:
+          context: org-global
+          requires:
+            - build_rpi3a
+            - build_rpi3
+            - build_rpi2
+            - build_rpi
+            - build_rpi0
+            - build_bbb
+            # - build_x86_64
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+* Initial release

--- a/nerves_key_quickstart_phx/assets/package-lock.json
+++ b/nerves_key_quickstart_phx/assets/package-lock.json
@@ -3315,6 +3315,57 @@
         "schema-utils": "^1.0.0"
       }
     },
+    "css-selector-tokenizer": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
+      "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1",
+        "regexpu-core": "^1.0.0"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+          "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4155,6 +4206,12 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
+    "fastparse": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+      "dev": true
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -4162,6 +4219,28 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-loader": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+      "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^0.4.5"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
       }
     },
     "filename-regex": {
@@ -5953,6 +6032,12 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
       "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
+    "jquery-ui": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
+      "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE=",
+      "dev": true
+    },
     "js-base64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
@@ -6932,6 +7017,11 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
+    },
+    "nestedSortable": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/nestedSortable/-/nestedSortable-1.3.4.tgz",
+      "integrity": "sha1-I7zUKURiuhF8F1HvVw3tFMuuM1Q="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -10864,6 +10954,28 @@
         "get-stdin": "^4.0.1"
       }
     },
+    "style-loader": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.21.0.tgz",
+      "integrity": "sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^0.4.5"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -11797,6 +11909,106 @@
         "yargs": "^11.1.0",
         "yeoman-environment": "^2.1.1",
         "yeoman-generator": "^2.0.5"
+      }
+    },
+    "webpack-jquery-ui": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-jquery-ui/-/webpack-jquery-ui-2.0.1.tgz",
+      "integrity": "sha512-ykG5qttZmTraCktCOgacVRAmD8TQi6N83smVH8D7/yahi63vH31uP0ZXN2o/qwNICn9GMLsi8jVjR0M3u2MEkw==",
+      "dev": true,
+      "requires": {
+        "css-loader": "^1.0.0",
+        "file-loader": "^1.1.11",
+        "jquery": "^3.3.1",
+        "jquery-ui": "^1.12.1",
+        "style-loader": "^0.21.0"
+      },
+      "dependencies": {
+        "css-loader": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
+          "integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "css-selector-tokenizer": "^0.7.0",
+            "icss-utils": "^2.1.0",
+            "loader-utils": "^1.0.2",
+            "lodash": "^4.17.11",
+            "postcss": "^6.0.23",
+            "postcss-modules-extract-imports": "^1.2.0",
+            "postcss-modules-local-by-default": "^1.2.0",
+            "postcss-modules-scope": "^1.1.0",
+            "postcss-modules-values": "^1.3.0",
+            "postcss-value-parser": "^3.3.0",
+            "source-list-map": "^2.0.0"
+          }
+        },
+        "icss-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+          "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+          "dev": true,
+          "requires": {
+            "postcss": "^6.0.1"
+          }
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "postcss-modules-extract-imports": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
+          "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+          "dev": true,
+          "requires": {
+            "postcss": "^6.0.1"
+          }
+        },
+        "postcss-modules-local-by-default": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+          "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+          "dev": true,
+          "requires": {
+            "css-selector-tokenizer": "^0.7.0",
+            "postcss": "^6.0.1"
+          }
+        },
+        "postcss-modules-scope": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+          "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+          "dev": true,
+          "requires": {
+            "css-selector-tokenizer": "^0.7.0",
+            "postcss": "^6.0.1"
+          }
+        },
+        "postcss-modules-values": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+          "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+          "dev": true,
+          "requires": {
+            "icss-replace-symbols": "^1.1.0",
+            "postcss": "^6.0.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "webpack-sources": {

--- a/nerves_key_quickstart_phx/assets/package.json
+++ b/nerves_key_quickstart_phx/assets/package.json
@@ -8,10 +8,10 @@
   "dependencies": {
     "bootstrap": "^4.1.3",
     "jquery": "^3.3.1",
-    "popper.js": "^1.14.3",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
-    "phoenix_live_view": "file:../deps/phoenix_live_view"
+    "phoenix_live_view": "file:../deps/phoenix_live_view",
+    "popper.js": "^1.14.3"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -19,13 +19,13 @@
     "babel-loader": "^8.0.0",
     "copy-webpack-plugin": "^4.5.0",
     "css-loader": "^2.1.1",
+    "extract-text-webpack-plugin": "~3.0",
     "mini-css-extract-plugin": "^0.4.0",
+    "node-sass": "^4.9.3",
     "optimize-css-assets-webpack-plugin": "^4.0.0",
+    "sass-loader": "^7.0.3",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "webpack": "4.4.0",
-    "webpack-cli": "^2.0.10",
-    "extract-text-webpack-plugin": "~3.0",
-    "node-sass": "^4.9.3",
-    "sass-loader": "^7.0.3"
+    "webpack-cli": "^2.0.10"
   }
 }

--- a/nerves_key_quickstart_phx/assets/webpack.config.js
+++ b/nerves_key_quickstart_phx/assets/webpack.config.js
@@ -5,7 +5,7 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const VENDOR_LIBS = [
-  'jquery', 'popper.js', 'webpack-jquery-ui', 'nestedSortable'
+  'jquery', 'popper.js'
 ]
 
 module.exports = (env, options) => ({
@@ -22,6 +22,14 @@ module.exports = (env, options) => ({
   output: {
     filename: '[name].js',
     path: path.resolve(__dirname, '../priv/static/js')
+  },
+  resolve : {
+    alias: {
+      // bind version of jquery-ui
+      "jquery-ui": "jquery-ui/jquery-ui.js",
+      // bind to modules;
+      modules: path.join(__dirname, "node_modules"),
+    }
   },
   module: {
     rules: [

--- a/nerves_key_quickstart_phx/lib/nerves_key_quickstart_phx_web/live/page_live/index.ex
+++ b/nerves_key_quickstart_phx/lib/nerves_key_quickstart_phx_web/live/page_live/index.ex
@@ -231,8 +231,8 @@ defmodule NervesKeyQuickstartPhxWeb.PageLive.Index do
     X509.Certificate.to_pem(cert)
   end
 
-  defp module_type_string(:ecc608_1), do: "ATECC608A Rev 1"
-  defp module_type_string(:ecc608_2), do: "ATECC608A Rev 2"
+  defp module_type_string(:ecc608a_1), do: "ATECC608A Rev 1"
+  defp module_type_string(:ecc608a_2), do: "ATECC608A Rev 2"
   defp module_type_string(:ecc508a), do: "ATECC508A"
   defp module_type_string(other), do: to_string(other)
 end

--- a/nerves_key_quickstart_phx/lib/nerves_key_quickstart_phx_web/live/page_live/index.ex
+++ b/nerves_key_quickstart_phx/lib/nerves_key_quickstart_phx_web/live/page_live/index.ex
@@ -19,7 +19,9 @@ defmodule NervesKeyQuickstartPhxWeb.PageLive.Index do
     module_type =
       if detected? do
         {:ok, info} = NervesKey.Config.device_info(transport)
+
         Map.get(info, :rev_num, "Error getting rev number")
+        |> module_type_string()
       end
 
     device_cert =
@@ -228,4 +230,9 @@ defmodule NervesKeyQuickstartPhxWeb.PageLive.Index do
   def cert_to_pem(cert) do
     X509.Certificate.to_pem(cert)
   end
+
+  defp module_type_string(:ecc608_1), do: "ATECC608A Rev 1"
+  defp module_type_string(:ecc608_2), do: "ATECC608A Rev 2"
+  defp module_type_string(:ecc508a), do: "ATECC508A"
+  defp module_type_string(other), do: to_string(other)
 end


### PR DESCRIPTION
This PR updates the Circle CI config to build multiple targets, firmware, and firmware images. On tagged releases, it will pull the release noted from the CHANGELOG.md and upload all the artifacts to Github releases. I've tested the firmware image that was created on a new Raspberry Pi 3a. I was able to configure a new NervesKey using it.